### PR TITLE
Add label information to correctness evaluation

### DIFF
--- a/src/esn_lab/pipeline/pred/predictor.py
+++ b/src/esn_lab/pipeline/pred/predictor.py
@@ -14,7 +14,6 @@ class Predictor:
 
 
     def predict(self, model:ESN, sample_id, U, D):
-        # Reset states per sample to avoid cross-sequence leakage
         model.Reservoir.reset_reservoir_state()
         model.y_prev = np.zeros(model.N_y)
 
@@ -42,6 +41,5 @@ class Predictor:
             id= sample_id,
             data= data
         )
-        
-        # return {sample_id : {TARGET_SERIES_KEY: D, OUTPUT_SERIES_KEY: np.array(Y_pred)}}
+
         return result


### PR DESCRIPTION
正誤判定にforaging, rumination, otherのそれぞれどれに該当するかというラベル情報を付与するようにした。
また、判別対象が増えても対応できるように、動的な判定にした。